### PR TITLE
Added 'posix=False' flag to shlex.split to allow windows paths

### DIFF
--- a/pyramid_assetmutator/mutator.py
+++ b/pyramid_assetmutator/mutator.py
@@ -234,11 +234,12 @@ class Mutator(object):
         cmd = '%s %s' % (self.mutator['cmd'], self.src_fullpath)
 
         proc = subprocess.Popen(
-            shlex.split(cmd),
+            shlex.split(cmd,posix=False),
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+
         data, err = proc.communicate()
 
         if proc.returncode != 0 or err:


### PR DESCRIPTION
Usage on windows still has some peculiarities, but at least it works with this addition. Without the posiix flag, all double backslashes are removed from the process path